### PR TITLE
Update README with accurate install/build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ Additionally, we now have a `headshots` folder for hosting prosecutor pictures. 
 ### Advanced (Developer experience)
 To help build the app:
 
-1. cd to repo/app
-2. `npm install`
-3. `meteor run`
-4. `meteor mongo`
+1. install `npm` ([see official docs](https://www.npmjs.com/get-npm))
+2. install `meteor` ([see official docs](https://www.meteor.com/install))
+3. `cd` into repo's `app` folder
+4. `meteor npm install`
+5. `meteor run`
+6. `meteor mongo`
 
 Production: https://us-prosecutor-database.herokuapp.com/
 


### PR DESCRIPTION
Fixes #72 

I'm updating the README to be more clear about installation steps for the app (especially because it uses `meteor`, which not everyone is familiar with). This also should fix an installation error produced by `npm` when only running `npm install` instead of the recommended `meteor npm install`.