### PR TITLE
Add Recently Updated section to home page

### DIFF
--- a/client/templates/pages/home.html
+++ b/client/templates/pages/home.html
@@ -11,27 +11,7 @@
       <div class="row mx-auto text-center">
         <h4>Recently Updated</h4>
       </div>
-      <div class="row my-5">
-          {{#if recentAttorneys}}
-            <ul>
-              {{#each recentAttorneys}}
-                <li class="col-sm-6 col-md-4 col-lg-3 single-attorney">
-                  <a class="card" href="{{pathFor 'attorneyView'}}">
-                    {{#if headshot}}
-                      <div class="thumbnail" style="background-image:url('{{headshot}}')"></div>
-                    {{else}}
-                      <div class="thumbnail" style="background-image:url('images/anon-prosecutor.jpg')"></div>
-                    {{/if}}
-                    <h3>{{name}}</h3>
-                    <h4>{{state}}</h4>
-                    <h4>{{role}}</h4>
-                    <h5><em>{{county}}</em></h5>
-                  </a>
-                </li>
-              {{/each}}
-            </ul>
-          {{/if}}
-      </div>
+      {{> recentlyUpdated}}
     </div>
   </section>
 

--- a/client/templates/sections/recently-updated.html
+++ b/client/templates/sections/recently-updated.html
@@ -1,0 +1,27 @@
+<template name="recentlyUpdated">
+    <div class="row">
+        {{#if recentUpdates 10}}
+        <table class="table">
+            <caption>Recently added prosecutors</caption>
+            <thead>
+            <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Role</th>
+                <th scope="col">State</th>
+            </tr>
+            </thead>
+            <tbody>
+            {{#each recentUpdates}}
+            <tr>
+                <th scope="row">
+                    <a href="{{pathFor 'attorneyView'}}">{{name}}</a>
+                </th>
+                <td>{{role}}</td>
+                <td>{{state}}</td>
+            </tr>
+            {{/each}}
+            </tbody>
+        </table>
+        {{/if}}
+    </div>
+</template>

--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -32,23 +32,19 @@ Template.registerHelper( 'findAttorneyType', (attorneyType) => {
 Template.currentProsecutors.helpers({
   allAttorneys() {
     return Attorneys.find().fetch();
-  },
-  recentAttorneys() {
-    return Attorneys.find( {}, {
-        sort: { timestamp : 1 },
-        limit: 6
-      }).fetch();
-    // dateExists(date) {
-    //   return date !== null;
-    // },
-    // unixToMMddYYYY(unix) {
-    //   var month = new Date(appointed * 1000).getMonth();
-    //   var day = new Date(appointed * 1000).getDate();
-    //   var year = new Date(appointed * 1000).getFullYear();
-    //   return month + '-' + date + '-' + year;
-    // }
   }
 });
+
+Template.recentlyUpdated.helpers({
+  recentUpdates(count) {
+    return Attorneys
+        .find({}, {
+          fields: { name: 1, role: 1, state: 1 },
+          sort: { '_id' : -1 },
+          limit: count
+        }).fetch();
+  }
+})
 
 Template.attorneyView.helpers({
   Attorneys() {


### PR DESCRIPTION
Solves #103

This populates the `Recently Updated` section of the home page.  By default, it will get the 10 (this number is customizable through the `count` parameter) latest entries in the `Attorneys`  DB.  This is done by reverse sorting the `_id` field.  If more granularity is required, it would be best to add something like a `timestamp` or `lastUpdated` field to the DB that this query could utilize.

It is formatted as a Bootstrap table for display efficiency and readability.  The name of the prosecutor is a link that goes to the `attorneyView` page for the clicked prosecutor.

![image](https://user-images.githubusercontent.com/738582/94985688-8e986d80-050d-11eb-97b3-8311c609584f.png)
