### PR TITLE
Mocha tests

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -27,3 +27,4 @@ underscore@1.0.10
 jquery
 http
 reactive-dict
+meteortesting:mocha

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -29,3 +29,4 @@ http
 reactive-dict
 meteortesting:mocha
 xolvio:cleaner
+dburles:factory

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -28,3 +28,4 @@ jquery
 http
 reactive-dict
 meteortesting:mocha
+xolvio:cleaner

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -49,6 +49,9 @@ livedata@1.0.18
 logging@1.1.20
 meteor@1.9.3
 meteor-base@1.4.0
+meteortesting:browser-tests@1.3.4
+meteortesting:mocha@2.0.1
+meteortesting:mocha-core@8.0.1
 mikowals:batch-insert@1.2.0
 minifier-css@1.5.3
 minifier-js@2.6.0

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -13,6 +13,7 @@ caching-compiler@1.2.2
 caching-html-compiler@1.1.3
 callback-hook@1.3.0
 check@1.3.1
+dburles:factory@1.1.0
 ddp@1.4.0
 ddp-client@2.3.3
 ddp-common@1.4.0

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -93,3 +93,4 @@ underscore@1.0.10
 url@1.3.1
 webapp@1.9.1
 webapp-hashing@1.0.9
+xolvio:cleaner@0.4.0

--- a/client/main.css
+++ b/client/main.css
@@ -466,12 +466,13 @@ section.articles {
 div#mocha {
   background: white;
   border-bottom: 2px solid black;
-  width: 100%;
+  /* height: 100%; */
   left: 0;
   margin: 0;
   overflow: auto;
   padding: 1rem;
-  position: fixed;
+  /* position: fixed; */
+  resize: vertical;
   top: 0;
   z-index: 1000;
 }

--- a/client/main.css
+++ b/client/main.css
@@ -461,3 +461,19 @@ section.articles {
 .single-attorney .card-footer {
   height: 75px;
 }
+
+/* Mocha Tests Styling (atmospherejs.com/meteortesting/mocha) */
+div#mocha {
+  background: white;
+  border-right: 2px solid black;
+  height: 100%;
+  left: 0;
+  margin: 0;
+  overflow: auto;
+  padding: 1rem;
+  position: fixed;
+  resize: horizontal;
+  top: 0;
+  width: 20px;
+  z-index: 1000;
+}

--- a/client/main.css
+++ b/client/main.css
@@ -465,15 +465,17 @@ section.articles {
 /* Mocha Tests Styling (atmospherejs.com/meteortesting/mocha) */
 div#mocha {
   background: white;
-  border-right: 2px solid black;
-  height: 100%;
+  border-bottom: 2px solid black;
+  width: 100%;
   left: 0;
   margin: 0;
   overflow: auto;
   padding: 1rem;
   position: fixed;
-  resize: horizontal;
   top: 0;
-  width: 20px;
   z-index: 1000;
+}
+
+ul#mocha-stats {
+  position: relative;
 }

--- a/imports/api/attorneys.test.js
+++ b/imports/api/attorneys.test.js
@@ -1,0 +1,70 @@
+import { assert } from 'chai';
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+import { Attorneys } from './attorneys';
+import faker from 'faker';
+
+const newAttorney = () => {
+  const attorneyModel = Factory.define('attorney', Attorneys, {
+    name: faker.fake("{{name.firstName}} {{name.lastName}}"),
+    role: faker.random.arrayElement([
+      'Attorney General',
+      'US Attorney',
+      'District Attorney',
+      'Municipal Attorney'
+    ]),
+    state: faker.address.state(true),
+    race: faker.random.arrayElement([
+      'American Indian',
+      'Asian',
+      'Black',
+      'Hispanic',
+      'Pacific Islander',
+      'White'
+    ]),
+  });
+  return attorneyModel;
+}
+
+describe('attorneys', function () {
+  beforeEach(function() {
+    resetDatabase();
+  });
+
+  it('stores an attorney', function() {
+    const attorneySource = newAttorney();
+    // Insert the new Attorney created by newAttorney() into the db
+    const attorneyRecord = Factory.create('attorney');
+    assert.equal(Attorneys.find().count(), 1);
+    Object.keys(attorneyRecord).forEach(key => {
+      if (attorneySource[key]) {
+        assert.equal(attorneyRecord[key], attorneySource.attributes[key])
+      };
+    });
+  });
+
+  it('reads an attorney', function () {
+    const attorneySource = newAttorney();
+    const attorneyRecord = Factory.create('attorney');
+    assert.isObject(Attorneys.find(attorneyRecord));
+  });
+
+  it('updates an attorney', function() {
+    const attorneySource = newAttorney();
+    const attorneyRecord = Factory.create('attorney');
+    const newName = faker.fake("{{name.firstName}} {{name.lastName}}");
+    Attorneys.update(
+      attorneyRecord,
+      { $set: { name: newName } },
+      async (error) => assert.isNull(error)
+      );
+  });
+
+  it('removes an Attorney', function () {
+    const attorneySource = newAttorney();
+    const attorneyRecord = Factory.create('attorney');
+    Attorneys.remove(
+      attorneyRecord,
+      async (error) => assert.isNull(error)
+      );
+  });
+})

--- a/imports/utils/denodeify.js
+++ b/imports/utils/denodeify.js
@@ -1,0 +1,13 @@
+/** Adapted from https://github.com/meteor/todos/blob/master/imports/utils/denodeify.js */
+import { Promise } from 'meteor/promise';
+
+// Convert an NPM-style function returning a callback to one that returns a Promise.
+export const denodeify = f => (...args) => new Promise((resolve, reject) => {
+  f(...args, (err, val) => {
+    if (err) {
+      reject(err);
+    } else {
+      resolve(val);
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -462,9 +462,9 @@
       }
     },
     "faker": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
-      "integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
       "dev": true
     },
     "get-func-name": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -461,6 +461,12 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "faker": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
+      "integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw==",
+      "dev": true
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,12 @@
         }
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -199,6 +205,26 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "cheerio": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
@@ -324,6 +350,15 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -425,6 +460,12 @@
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "hash-base": {
       "version": "3.1.0",
@@ -810,6 +851,12 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz",
       "integrity": "sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g=="
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
@@ -1073,6 +1120,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "url": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "meteor-node-stubs": "~1.0.1",
     "moment": "^2.29.0",
     "simpl-schema": "^1.5.6"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "simpl-schema": "^1.5.6"
   },
   "devDependencies": {
-    "chai": "^4.2.0"
+    "chai": "^4.2.0",
+    "faker": "^5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "faker": "^5.1.0"
+    "faker": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "author": "Billimarie Lubiano Robinson <work@billimarie.com>",
   "license": "GNU GPLv3",
   "scripts": {
+    "test": "meteor test --driver-package meteortesting:mocha --once",
+    "test-watch": "meteor test --driver-package meteortesting:mocha",
+    "test-app": "meteor test --driver-package meteortesting:mocha --once --full-app",
+    "test-app-watch": "meteor test --driver-package meteortesting:mocha --full-app",
     "start": "meteor run"
   },
   "dependencies": {


### PR DESCRIPTION
## Added Packages

Atmosphere:

- [meteortesting:mocha](https://atmospherejs.com/meteortesting/mocha)*: Required testing package
- [xolvio:cleaner](https://atmospherejs.com/xolvio/cleaner)*: Reset test database quickly & easily
- [dburles:factory](https://atmospherejs.com/dburles/factory): Inserts test data from faker

*These packages don't load in production

NPM devDependencies:

- [chai](https://www.npmjs.com/package/chai): Includes the `assert` library for tests
- [faker](https://www.npmjs.com/package/faker): Generate bulk fake data for testing

These packages will be bundled in production unless `meteor npm prune --production` is used to remove the devDependancies!

## Added scripts

Run with `meteor npm [script]`

Unit testing:

- `test`: Runs one test (without loading the client), eager-loading any `*.test.js` files present in the directory (files under a `./test/` directory are ignored )
- `test-watch`: Build & run test server, hot reloading on file changes. Server tests will happen in the command line, and the same tests are available on the client by opening [localhost:3000](localhost:3000). Very useful for unit testing during development!

Integration testing (client):

- `test-app`: Build & run the full stack, including client, then run tests once. Loads any `*.app-test.js` files present outside of `./test/` (does not load `*.test.js` files).
- `test-app-watch`: Build & run full stack, including client. Hot reload on file changes, just like `meteor run`. Also inserts a `<div>` with test results at the top of the page.

Note that for `test-watch`, Iron Router appends a routing error to the end of the page. This is because the client isn't being delivered as IR expects it to be. It doesn't interfere with the function of the script, it's just an eyesore. I haven't adressed it, because I figured it would change with #158.

Also note that you cannot `meteor mongo` while a test instance is running because **a test instance uses a test database on port :3001**. If you have a local mongo client, you can connect with `mongo meteor --port 3001`.

At present, I haven't written any Integration tests due to difficulty with the current publications. I'm having trouble figuring out the best method to subscribe to a publication that includes all attorneys in the client, given how the current publications are structured. I wanted to get this PR out before moving on to inegration tests.
